### PR TITLE
Clan tags not loading on "Load More" for user profiles

### DIFF
--- a/inspector.user.js
+++ b/inspector.user.js
@@ -439,6 +439,7 @@
         await runUsernames();
         await runScoreRankCompletionPercentages();
     }
+
     // - Second run(); call removed as it seems unnecessary
     // run();
 
@@ -852,6 +853,13 @@
         const observer = new MutationObserver((mutationsList, observer) => {
             for (let mutation of mutationsList) {
                 if (mutation.type === 'childList') {
+                    // On the user profile, update clan tags when "Load More" is called.
+                    if (window.location.href.includes("/users/") || window.location.href.includes("/u/")) {
+                        if (mutation.target.classList.contains("osu-layout__col-container")) {
+                            _func();
+                        }
+                    }
+
                     if (window.location.href.includes("/beatmapsets/")) {
                         if (mutation.target.classList.contains("beatmapset-scoreboard__main")) {
                             _func();

--- a/inspector.user.js
+++ b/inspector.user.js
@@ -439,7 +439,8 @@
         await runUsernames();
         await runScoreRankCompletionPercentages();
     }
-    run();
+    // - Second run(); call removed as it seems unnecessary
+    // run();
 
     async function handleHeader() {
         //find 3rd with class "nav2__col nav2__col--menu"


### PR DESCRIPTION
In the beatmap section on a user profile, for example. Clicking "Load More" will not populate the newly created username elements with clan tags. I've created an observer which will listen to changes on `.osu-layout__col-container`.

There is also another commit which addresses a duplicate call to run(). I did not see the purpose of this call, I have removed it as it is causing unnecessary network requests to my knowledge. 