### PR TITLE
fix double run()

### DIFF
--- a/inspector.user.js
+++ b/inspector.user.js
@@ -50,10 +50,6 @@
     // let CURRENT_GRAPH = 'Performance';
     let CURRENT_GRAPH = GM_getValue("inspector_current_graph", "Performance");
 
-    document.addEventListener("turbolinks:load", async function () {
-        await run();
-    });
-
     //lets script know what elements to wait for before running
     const PAGE_ELEMENT_WAIT_LIST = {
         'user_page': '.profile-info__name',
@@ -434,7 +430,7 @@
         await runScoreRankCompletionPercentages();
     }
 
-    run();
+    run().then(() => document.addEventListener("turbolinks:load", run));
 
     async function handleLeaderboardPage() {
         //find ul with class "header-nav-v4 header-nav-v4--list"


### PR DESCRIPTION
add turbolinks:load event listener only after first initial run() to prevent it sometimes runs twice on same page

can be reproduce by ctrl+f5 or "open link in incognito window" or clear browser cache and reload

also fix #9

![image](https://github.com/user-attachments/assets/628abcc0-336c-44a9-a4a7-bd0f0de3e7a3)
![image](https://github.com/user-attachments/assets/85d8f68d-6b90-4f0e-96b3-4872900e3dba)


