### PR TITLE
Popup if user not available.

### DIFF
--- a/inspector.user.js
+++ b/inspector.user.js
@@ -2018,6 +2018,16 @@
 
         const data = await getUserData(user_id, username, mode);
 
+        const user_exists = data.user != null &&
+            (typeof data.coe !== "undefined" || typeof data.coe.error !== "string")
+            
+        //if the user does not exist, give informational alert.
+        if (!user_exists) {
+            popup("No osu!alt statistics available for this user.");
+            //skip other checks as redundant
+            return;
+        }
+
         if (data.coe && !data.coe.error) {
             setOrCreateCoeBannerElement(data.coe);
         }


### PR DESCRIPTION
### Informational
- Tested on `Mozilla/5.0 (X11; Linux x86_64; rv:133.0) Gecko/20100101 Firefox/133.0` for accounts without COE entries, with COE entries, and without statistics available.
- Implement an informational alert using existing `popup()` functionality.
- Adds `user_exists` constant to `getUserData()`.

This was implemented due to the following to-do: A notification if user has no osu!alt statistics available

### Comments / Concerns
Is there a better way to check if a user exists in the osu!alt database? I added COE checks as I'm unaware if a user can exist with a COE entry but not exist in the statistics database.
Is the popup too intrusive / stays up for too long? Functionality could be modified to change sizing, timing, opacity, etc... as required.

### Images
![image](https://github.com/user-attachments/assets/56d35973-ce38-42e0-a56a-cb9b4c79c3e2)